### PR TITLE
Restore some 1.7.10 behaviour (+ some things)

### DIFF
--- a/src/main/java/cpw/mods/ironchest/BlockIronChest.java
+++ b/src/main/java/cpw/mods/ironchest/BlockIronChest.java
@@ -10,6 +10,7 @@
  ******************************************************************************/
 package cpw.mods.ironchest;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Random;
 
@@ -20,6 +21,7 @@ import net.minecraft.block.properties.PropertyEnum;
 import net.minecraft.block.state.BlockState;
 import net.minecraft.block.state.IBlockState;
 import net.minecraft.creativetab.CreativeTabs;
+import net.minecraft.entity.Entity;
 import net.minecraft.entity.EntityLivingBase;
 import net.minecraft.entity.item.EntityItem;
 import net.minecraft.entity.player.EntityPlayer;
@@ -32,9 +34,13 @@ import net.minecraft.tileentity.TileEntity;
 import net.minecraft.util.BlockPos;
 import net.minecraft.util.EnumFacing;
 import net.minecraft.util.MathHelper;
+import net.minecraft.world.Explosion;
+import net.minecraft.world.IBlockAccess;
 import net.minecraft.world.World;
 import net.minecraftforge.fml.relauncher.Side;
 import net.minecraftforge.fml.relauncher.SideOnly;
+
+import com.google.common.collect.Lists;
 
 public class BlockIronChest extends BlockContainer
 {
@@ -80,10 +86,10 @@ public class BlockIronChest extends BlockContainer
             return true;
         }
 
-        /*if (world.isSideSolid(i, j + 1, k, ForgeDirection.DOWN))
+        if (world.isSideSolid(pos.add(0, 1, 0), EnumFacing.DOWN))
         {
             return true;
-        }*/
+        }
 
         if (world.isRemote)
         {
@@ -131,15 +137,15 @@ public class BlockIronChest extends BlockContainer
         return new BlockState(this, new IProperty[] { VARIANT_PROP });
     }
 
-    /*@Override
-    public ArrayList<ItemStack> getDrops(World world, int x, int y, int z, int metadata, int fortune)
+    @Override
+    public ArrayList<ItemStack> getDrops(IBlockAccess world, BlockPos pos, IBlockState state, int fortune)
     {
         ArrayList<ItemStack> items = Lists.newArrayList();
-        ItemStack stack = new ItemStack(this,1,metadata);
-        IronChestType.values()[IronChestType.validateMeta(metadata)].adornItemDrop(stack);
+        ItemStack stack = new ItemStack(this,1,getMetaFromState(state));
+        IronChestType.values()[IronChestType.validateMeta(getMetaFromState(state))].adornItemDrop(stack);
         items.add(stack);
         return items;
-    }*/
+    }
 
     @Override
     public void onBlockAdded(World world, BlockPos pos, IBlockState blockState)
@@ -234,20 +240,20 @@ public class BlockIronChest extends BlockContainer
         }
     }
 
-    /*@Override
-    public float getExplosionResistance(Entity par1Entity, World world, int x, int y, int z, double explosionX, double explosionY, double explosionZ)
+    @Override
+    public float getExplosionResistance(World world, BlockPos pos, Entity exploder, Explosion explosion)
     {
-       TileEntity te = world.getTileEntity(x, y, z);
+       TileEntity te = world.getTileEntity(pos);
        if (te instanceof TileEntityIronChest)
        {
            TileEntityIronChest teic = (TileEntityIronChest) te;
            if (teic.getType().isExplosionResistant())
            {
-               return 10000f;
+               return 10000F;
            }
        }
-       return super.getExplosionResistance(par1Entity, world, x, y, z, explosionX, explosionY, explosionZ);
-    }*/
+       return super.getExplosionResistance(world, pos, exploder, explosion);
+    }
 
     @Override
     public boolean hasComparatorInputOverride() {
@@ -265,30 +271,29 @@ public class BlockIronChest extends BlockContainer
         return 0;
     }
 
-    /*private static final ForgeDirection[] validRotationAxes = new ForgeDirection[] { UP, DOWN };
+    private static final EnumFacing[] validRotationAxes = new EnumFacing[] { EnumFacing.UP, EnumFacing.DOWN };
     @Override
-    public ForgeDirection[] getValidRotations(World worldObj, int x, int y, int z)
+    public EnumFacing[] getValidRotations(World worldObj, BlockPos pos)
     {
         return validRotationAxes;
     }
 
     @Override
-    public boolean rotateBlock(World worldObj, int x, int y, int z, ForgeDirection axis)
+    public boolean rotateBlock(World worldObj, BlockPos pos, EnumFacing axis)
     {
         if (worldObj.isRemote)
         {
             return false;
         }
-        if (axis == UP || axis == DOWN)
+        if (axis == EnumFacing.UP || axis == EnumFacing.DOWN)
         {
-            TileEntity tileEntity = worldObj.getTileEntity(x, y, z);
+            TileEntity tileEntity = worldObj.getTileEntity(pos);
             if (tileEntity instanceof TileEntityIronChest) {
                 TileEntityIronChest icte = (TileEntityIronChest) tileEntity;
-                icte.rotateAround(axis);
+                icte.rotateAround();
             }
             return true;
         }
         return false;
-    }*/
-
+    }
 }

--- a/src/main/java/cpw/mods/ironchest/ChestChangerType.java
+++ b/src/main/java/cpw/mods/ironchest/ChestChangerType.java
@@ -14,14 +14,10 @@ import static cpw.mods.ironchest.IronChestType.IRON;
 import static cpw.mods.ironchest.IronChestType.OBSIDIAN;
 import static cpw.mods.ironchest.IronChestType.SILVER;
 import static cpw.mods.ironchest.IronChestType.WOOD;
-import cpw.mods.ironchest.client.ModelHelper;
-import net.minecraft.client.Minecraft;
-import net.minecraft.client.renderer.entity.RenderItem;
 import net.minecraft.init.Blocks;
 import net.minecraft.item.ItemStack;
-import net.minecraftforge.fml.common.FMLCommonHandler;
 import net.minecraftforge.fml.common.registry.GameRegistry;
-import net.minecraftforge.fml.relauncher.Side;
+import cpw.mods.ironchest.client.ModelHelper;
 
 public enum ChestChangerType {
     IRONGOLD(IRON, GOLD, "ironGoldUpgrade", "Iron to Gold Chest Upgrade", "mmm", "msm", "mmm"),

--- a/src/main/java/cpw/mods/ironchest/IronChest.java
+++ b/src/main/java/cpw/mods/ironchest/IronChest.java
@@ -12,6 +12,7 @@ package cpw.mods.ironchest;
 
 import net.minecraft.client.Minecraft;
 import net.minecraft.init.Blocks;
+import net.minecraftforge.common.MinecraftForge;
 import net.minecraftforge.fml.common.Mod;
 import net.minecraftforge.fml.common.Mod.EventHandler;
 import net.minecraftforge.fml.common.Mod.Instance;
@@ -40,8 +41,6 @@ public class IronChest
         PacketHandler.INSTANCE.ordinal();
     }
 
-    private static boolean run = false;
-    
     @EventHandler
     public void load(FMLInitializationEvent evt)
     {
@@ -63,9 +62,6 @@ public class IronChest
         ChestChangerType.generateRecipes();
         NetworkRegistry.INSTANCE.registerGuiHandler(instance, proxy);
         proxy.registerRenderInformation();
-//        if (OCELOTS_SITONCHESTS)
-//        {
-//            MinecraftForge.EVENT_BUS.register(new OcelotsSitOnChestsHandler());
-//        }
+        MinecraftForge.EVENT_BUS.register(new OcelotsSitOnChestsHandler());
     }
 }

--- a/src/main/java/cpw/mods/ironchest/IronChestAIOcelotSit.java
+++ b/src/main/java/cpw/mods/ironchest/IronChestAIOcelotSit.java
@@ -2,6 +2,8 @@ package cpw.mods.ironchest;
 
 import net.minecraft.entity.ai.EntityAIOcelotSit;
 import net.minecraft.entity.passive.EntityOcelot;
+import net.minecraft.util.BlockPos;
+import net.minecraft.world.World;
 
 public class IronChestAIOcelotSit extends EntityAIOcelotSit 
 {
@@ -10,13 +12,13 @@ public class IronChestAIOcelotSit extends EntityAIOcelotSit
         super(par1EntityOcelot, par2);
     }
 
-/*    @Override
-    protected boolean func_151486_a(World world, int x, int y, int z)
+    @Override
+    protected boolean func_179488_a(World world, BlockPos pos)
     {
-        if (world.getBlock(x, y, z) == IronChest.ironChestBlock)
+        if (world.getBlockState(pos).getBlock() == IronChest.ironChestBlock)
         {
             return true;
         }
-        return super.func_151486_a(world, x, y, z);
+        return super.func_179488_a(world, pos);
     }
-*/}
+}

--- a/src/main/java/cpw/mods/ironchest/IronChestType.java
+++ b/src/main/java/cpw/mods/ironchest/IronChestType.java
@@ -15,7 +15,6 @@ import java.util.Arrays;
 import java.util.List;
 
 import net.minecraft.init.Blocks;
-import net.minecraft.init.Items;
 import net.minecraft.inventory.IInventory;
 import net.minecraft.inventory.Slot;
 import net.minecraft.item.Item;
@@ -204,9 +203,6 @@ public enum IronChestType implements IStringSerializable
         return this == OBSIDIAN;
     }
 
-    private static String[] sideNames = { "top", "front", "side" };
-    private static int[] sideMapping = { 0, 0, 2, 1, 2, 2, 2 };
-
     public Slot makeSlot(IInventory chestInventory, int index, int x, int y)
     {
         return new ValidatingSlot(chestInventory, index, x, y, this);
@@ -216,6 +212,7 @@ public enum IronChestType implements IStringSerializable
     {
         return itemFilter == null || itemstack == null || itemstack.getItem() == itemFilter;
     }
+    
     public void adornItemDrop(ItemStack item)
     {
         if (this == DIRTCHEST9000)

--- a/src/main/java/cpw/mods/ironchest/ItemChestChanger.java
+++ b/src/main/java/cpw/mods/ironchest/ItemChestChanger.java
@@ -10,7 +10,6 @@
  ******************************************************************************/
 package cpw.mods.ironchest;
 
-import net.minecraft.block.Block;
 import net.minecraft.creativetab.CreativeTabs;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.init.Blocks;
@@ -22,8 +21,6 @@ import net.minecraft.util.BlockPos;
 import net.minecraft.util.EnumFacing;
 import net.minecraft.world.World;
 import net.minecraftforge.fml.common.ObfuscationReflectionHelper;
-import net.minecraftforge.fml.relauncher.Side;
-import net.minecraftforge.fml.relauncher.SideOnly;
 
 public class ItemChestChanger extends Item 
 {

--- a/src/main/java/cpw/mods/ironchest/OcelotsSitOnChestsHandler.java
+++ b/src/main/java/cpw/mods/ironchest/OcelotsSitOnChestsHandler.java
@@ -5,9 +5,11 @@ import java.util.List;
 import net.minecraft.entity.ai.EntityAIOcelotSit;
 import net.minecraft.entity.ai.EntityAITasks;
 import net.minecraft.entity.passive.EntityOcelot;
+import net.minecraftforge.event.entity.living.LivingEvent;
 import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
 
-/*public class OcelotsSitOnChestsHandler {
+public class OcelotsSitOnChestsHandler {
+	
     @SubscribeEvent
     public void changeSittingTaskForOcelots(LivingEvent.LivingUpdateEvent evt)
     {
@@ -24,4 +26,4 @@ import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
             }
         }
     }
-}*/
+}

--- a/src/main/java/cpw/mods/ironchest/TileEntityIronChest.java
+++ b/src/main/java/cpw/mods/ironchest/TileEntityIronChest.java
@@ -26,6 +26,7 @@ import net.minecraft.network.Packet;
 import net.minecraft.server.gui.IUpdatePlayerListBox;
 import net.minecraft.tileentity.TileEntityLockable;
 import net.minecraft.util.AxisAlignedBB;
+import net.minecraft.util.EnumFacing;
 
 public class TileEntityIronChest extends TileEntityLockable implements IUpdatePlayerListBox, IInventory 
 {
@@ -519,13 +520,16 @@ public class TileEntityIronChest extends TileEntityLockable implements IUpdatePl
         return type.acceptsStack(itemstack);
     }
 
-
-
-    /*void rotateAround(ForgeDirection axis)
+    void rotateAround()
     {
-        setFacing((byte)ForgeDirection.getOrientation(facing).getRotation(axis).ordinal());
-        worldObj.addBlockEvent(this.xCoord, this.yCoord, this.zCoord, IronChest.ironChestBlock, 2, getFacing());
-    }*/
+    	facing++;
+    	if(facing > EnumFacing.EAST.ordinal())
+    	{
+    		facing = EnumFacing.NORTH.ordinal();
+    	}
+        setFacing(facing);
+        worldObj.addBlockEvent(pos, IronChest.ironChestBlock, 2, facing);
+    }
 
     public void wasPlaced(EntityLivingBase entityliving, ItemStack itemStack)
     {
@@ -568,5 +572,10 @@ public class TileEntityIronChest extends TileEntityLockable implements IUpdatePl
     {
         return "IronChest:" + type.name();
     }
-
+    
+    @Override
+    public boolean canRenderBreaking()
+    {
+    	return true;
+    }
 }


### PR DESCRIPTION
-Ocelots will sit on chests
-Chests won't open if there's a solid block on top of it
-Obsidian chest is explosion resistant
-Fixed getDrops
-Chests are rotatable again
-No more direct GL calls

Also:
-Cleaned up a bunch of imports and unused fields
-Chests now render the breaking animation.
-Disabled face culling for crystal chests (makes them look cooler:3)
