### PR TITLE
Added support for Inventory Tweaks

### DIFF
--- a/src/main/java/cpw/mods/ironchest/ContainerIronChest.java
+++ b/src/main/java/cpw/mods/ironchest/ContainerIronChest.java
@@ -10,6 +10,7 @@
  ******************************************************************************/
 package cpw.mods.ironchest;
 
+import invtweaks.api.container.ChestContainer;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.entity.player.InventoryPlayer;
 import net.minecraft.inventory.Container;
@@ -17,6 +18,7 @@ import net.minecraft.inventory.IInventory;
 import net.minecraft.inventory.Slot;
 import net.minecraft.item.ItemStack;
 
+@ChestContainer(isLargeChest = true)
 public class ContainerIronChest extends Container {
     private IronChestType type;
     private EntityPlayer player;
@@ -116,6 +118,7 @@ public class ContainerIronChest extends Container {
         return player;
     }
     
+    @ChestContainer.RowSizeCallback
     public int getNumColumns() {
         return type.getRowLength();
     }


### PR DESCRIPTION
I chose to set the property **isLargeChest** to **true** because this makes the buttons of Inventory Tweaks render on the right side vertically.

If this property is set to **false** the buttons are rendered on the left top horizontally but this make the buttons really weird, half inside and half outside the chest gui.

Fix #55 and #32 