### PR TITLE
Update Iron Chests to 1.12.1!

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -33,7 +33,7 @@ repositories {
 }
 
 dependencies {
-    deobfCompile "mezz.jei:jei_1.12:4.7.0.+"
+    deobfCompile "mezz.jei:jei_1.12.1:4.7.7.+"
 }
 
 // This is our group. I'm cpw.mods
@@ -46,8 +46,8 @@ targetCompatibility = 1.8
 
 // Setup the forge minecraft plugin data. Specify the preferred forge/minecraft version here
 minecraft {
-    version = "1.12-14.21.0.2375"
-    mappings = "snapshot_20170627"
+    version = "1.12.1-14.22.0.2452"
+    mappings = "snapshot_20170811"
     runDir = "run"
 }
 


### PR DESCRIPTION
I am relatively new to creating or updating forge mods, but I believe I made the minimum edits to get Iron Chests working in Minecraft 1.12.1.  I played with a locally compiled version with this patch for about 8 hours on 1.12.1 today and did not experience any crashing or other issues.