### PR TITLE
Don't send the entire NBT tag to the client

### DIFF
--- a/src/main/java/cpw/mods/ironchest/common/tileentity/chest/TileEntityIronChest.java
+++ b/src/main/java/cpw/mods/ironchest/common/tileentity/chest/TileEntityIronChest.java
@@ -593,7 +593,9 @@ public class TileEntityIronChest extends TileEntityLockableLoot implements ITick
     @Override
     public NBTTagCompound getUpdateTag()
     {
-        return this.writeToNBT(new NBTTagCompound());
+        NBTTagCompound compound = super.getUpdateTag();
+        compound.setByte("facing", (byte) this.facing.ordinal());
+        return compound;
     }
 
     @Override

--- a/src/main/java/cpw/mods/ironchest/common/tileentity/shulker/TileEntityIronShulkerBox.java
+++ b/src/main/java/cpw/mods/ironchest/common/tileentity/shulker/TileEntityIronShulkerBox.java
@@ -673,7 +673,9 @@ public class TileEntityIronShulkerBox extends TileEntityLockableLoot implements 
     @Override
     public NBTTagCompound getUpdateTag()
     {
-        return this.writeToNBT(new NBTTagCompound());
+        NBTTagCompound compound = super.getUpdateTag();
+        compound.setByte("facing", (byte) this.facing.ordinal());
+        return compound;
     }
 
     @Override


### PR DESCRIPTION
The only extra bit of NBT the client needs here is facing. If we send
everything, then the client will know about the loot table when there is one,
which will result in this crash:

```
java.lang.NullPointerException: Rendering screen
	at net.minecraft.tileentity.TileEntityLockableLoot.fillWithLoot(TileEntityLockableLoot.java:59)
	at cpw.mods.ironchest.common.tileentity.chest.TileEntityIronChest.getStackInSlot(TileEntityIronChest.java:138)
	at net.minecraft.inventory.Slot.getStack(Slot.java:81)
	at net.minecraft.client.gui.inventory.GuiContainer.drawSlot(GuiContainer.java:234)
	at net.minecraft.client.gui.inventory.GuiContainer.drawScreen(GuiContainer.java:116)
	at cpw.mods.ironchest.client.gui.chest.GUIChest.drawScreen(GUIChest.java:100)
	at net.minecraftforge.client.ForgeHooksClient.drawScreen(ForgeHooksClient.java:368)
	at net.minecraft.client.renderer.EntityRenderer.updateCameraAndRender(EntityRenderer.java:1177)
	at net.minecraft.client.Minecraft.runGameLoop(Minecraft.java:1207)
	at net.minecraft.client.Minecraft.run(Minecraft.java:441)
	at net.minecraft.client.main.Main.main(Main.java:118)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at net.minecraft.launchwrapper.Launch.launch(Launch.java:135)
	at net.minecraft.launchwrapper.Launch.main(Launch.java:28)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at net.minecraftforge.gradle.GradleStartCommon.launch(GradleStartCommon.java:97)
	at GradleStart.main(GradleStart.java:25)
```