### PR TITLE
Don't markDirty() when inserting into a full slot 

### DIFF
--- a/src/main/java/cpw/mods/ironchest/common/lib/ICChestInventoryHandler.java
+++ b/src/main/java/cpw/mods/ironchest/common/lib/ICChestInventoryHandler.java
@@ -79,10 +79,11 @@ public class ICChestInventoryHandler implements IItemHandlerModifiable
         }
         else
         {
-            if (!ItemHandlerHelper.canItemStacksStack(stack, currentStack))
+            int accepted = Math.min(stack.getMaxStackSize(), inv.getInventoryStackLimit()) - currentStack.getCount();
+
+            if (accepted <= 0 || !ItemHandlerHelper.canItemStacksStack(stack, currentStack))
                 return stack;
 
-            int accepted = Math.min(stack.getMaxStackSize(), inv.getInventoryStackLimit()) - currentStack.getCount();
             if (accepted < stack.getCount())
             {
                 if (!simulate)

--- a/src/main/java/cpw/mods/ironchest/common/lib/ICShulkerInventoryHandler.java
+++ b/src/main/java/cpw/mods/ironchest/common/lib/ICShulkerInventoryHandler.java
@@ -79,10 +79,11 @@ public class ICShulkerInventoryHandler implements IItemHandlerModifiable
         }
         else
         {
-            if (!ItemHandlerHelper.canItemStacksStack(stack, currentStack))
+            int accepted = Math.min(stack.getMaxStackSize(), inv.getInventoryStackLimit()) - currentStack.getCount();
+
+            if (accepted <= 0 || !ItemHandlerHelper.canItemStacksStack(stack, currentStack))
                 return stack;
 
-            int accepted = Math.min(stack.getMaxStackSize(), inv.getInventoryStackLimit()) - currentStack.getCount();
             if (accepted < stack.getCount())
             {
                 if (!simulate)


### PR DESCRIPTION
When inserting into a full slot, the inventory is not actually modified but `markDirty()` is still called. This in turn sends a block update to all neighbours. When a diamond chest is full, attempting to insert into it will trigger 100+ block updates (one for each slot) for each neighbour.