### PR TITLE
Potential or partial solution to #179: remove ItemStack::copy.

### DIFF
--- a/src/main/java/cpw/mods/ironchest/common/lib/ICChestInventoryHandler.java
+++ b/src/main/java/cpw/mods/ironchest/common/lib/ICChestInventoryHandler.java
@@ -42,7 +42,6 @@ public class ICChestInventoryHandler implements IItemHandlerModifiable
     {
         if (stack.isEmpty())
             return stack;
-        stack = stack.copy();
 
         if (!inv.isItemValidForSlot(slot, stack))
             return stack;

--- a/src/main/java/cpw/mods/ironchest/common/lib/ICShulkerInventoryHandler.java
+++ b/src/main/java/cpw/mods/ironchest/common/lib/ICShulkerInventoryHandler.java
@@ -42,7 +42,6 @@ public class ICShulkerInventoryHandler implements IItemHandlerModifiable
     {
         if (stack.isEmpty())
             return stack;
-        stack = stack.copy();
 
         if (!inv.isItemValidForSlot(slot, stack))
             return stack;


### PR DESCRIPTION
From my own profiling (which unfortunately I don't have a copy of) of a
situation which involved a single chicken on a hopper attached to a
diamond chest, I noticed that there was a significant slowdown related
to IronChests's item handler.

Specifically (and perhaps exacerbated by the hopper's functionality)
every time an item was "inserted", capability events would be fired and
responded to by a number of mods, resulting in slowdown. This was
compounded as it happened continuously every time it tried to insert the
egg for every single slot.

This seems to be caused by the ItemStack copy in both of the main
inventory handlers.

Looking at their Vanilla equivalents, there doesn't appear to be any
canonical reason for this (as Vanilla does not copy), and it appears as
though it is to be expected that `insertItem` will modify your itemstack
in some way.