### PR TITLE
Update to Minecraft 1.14.4

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -7,12 +7,12 @@ org.gradle.daemon=false
 mod_version=9.0
 
 # Minecraft Version Information
-minecraft_version=1.14.3
+minecraft_version=1.14.4
 minecraft_version_toml=14
 
 # Forge Version Information
-forge_version=27.0.60
-forge_version_toml=27
+forge_version=28.0.29
+forge_version_toml=28
 
 # Mappings Information
-mappings_version=20190719-1.14.3
+mappings_version=20190802-1.14.3


### PR DESCRIPTION
Updated Forge version to 28.0.29, game version to 1.14.4 and mappings version to 20190802-1.14.3

Built successfully and tested it on Minecraft 1.14.4. Seems to be working fine.