### PR TITLE
[Iron Chets] Added a compatibility json file for Public Gui Announcement

### DIFF
--- a/src/main/resources/assets/ironchest/load_screens/pga_compat.json
+++ b/src/main/resources/assets/ironchest/load_screens/pga_compat.json
@@ -1,0 +1,7 @@
+{
+	"screens" : [{
+			"COMMENT" : "Public Gui Anouncement support", 
+			"class" : "com.progwml6.ironchest.common.inventory.ChestContainer", 
+			"texture" : "minecraft:textures/gui/container/generic_54.png"
+		}]
+}


### PR DESCRIPTION
the PGA :
https://www.curseforge.com/minecraft/mc-mods/public-gui-announcement

The Wiki on how these JSON files work :
https://github.com/ArtixAllMighty/PublicGuiAnnouncement/wiki/Add-Mod-Compatibility

In this PR is contained one json file to add compatibility with the mod Public Gui Announcement.
I wanted to ship the compat at first with my mod, but it would be better if the author maintains it himself. (in case of path and name changes as well addition or removal from screens).

I hereby give you all files needed to add compatibility to my mod. There is nothing else left to do apart from merging the PR.

If you have any other question, I'd be happy to answer !

P.S : I opted for the vanilla container chest image to display, because Iron Chests doesn't have different containers or screens I can use to identify each one from one another, and I didnt know which one to pick as a standard. Furthermore can resourcepacks that modify the chest container image now also show on PGA, without breaking immersion too much