### PR TITLE
Crystal chest item rotation fix

### DIFF
--- a/src/main/java/com/progwml6/ironchest/client/render/IronChestTileEntityRenderer.java
+++ b/src/main/java/com/progwml6/ironchest/client/render/IronChestTileEntityRenderer.java
@@ -146,7 +146,7 @@ public class IronChestTileEntityRenderer<T extends TileEntity & IChestLid> exten
     Vector3f center = modelItem.getCenter();
     matrices.translate(center.getX(), center.getY(), center.getZ());
 
-    matrices.rotate(Vector3f.YP.rotation(rotation));
+    matrices.rotate(Vector3f.YP.rotationDegrees(rotation));
 
     // scale
     float scale = modelItem.getSizeScaled();


### PR DESCRIPTION
The items spin too fast in the crystal chest. This PR fixes this issue.
Indeed, the rotation is in degrees, but "rotation" expects an angle in radians. Therefore, "rotationDegrees" should be used instead.